### PR TITLE
Exclude tests from autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "autoload": {
         "psr-4": {
             "Arxus\\NewrelicMessengerBundle\\": ""
-        }
+        },
+        "exclude-from-classmap": ["tests/"]
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
Excluding tests from production autoloading should fix this warning:

![image](https://user-images.githubusercontent.com/2707563/222700290-7f73300a-92ab-4834-bd84-151707c63972.png)


I also thought of creating a `/src` folder for the actual source files, but I think exclude is fine for now.