### PR TITLE
Allow using Messenger's Stamps

### DIFF
--- a/Middleware/NewRelicMiddleware.php
+++ b/Middleware/NewRelicMiddleware.php
@@ -4,10 +4,12 @@ namespace Arxus\NewrelicMessengerBundle\Middleware;
 
 use Arxus\NewrelicMessengerBundle\Newrelic\NewrelicManager;
 use Arxus\NewrelicMessengerBundle\Newrelic\NewrelicTransactionNameManager;
+use Arxus\NewrelicMessengerBundle\Newrelic\NewrelicTransactionStamp;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 
 class NewRelicMiddleware implements MiddlewareInterface
 {
@@ -33,15 +35,32 @@ class NewRelicMiddleware implements MiddlewareInterface
             return $stack->next()->handle($envelope, $stack);
         }
 
-        $this->newrelicManager->startTransaction();
-        $this->newrelicManager->nameTransaction($this->newrelicTransactionNameManager->getTransactionName($envelope));
-        try {
-            return $stack->next()->handle($envelope, $stack);
-        } catch (HandlerFailedException $e) {
-            $this->newrelicManager->noticeError($e);
-            throw $e;
-        } finally {
-            $this->newrelicManager->endTransaction();
+        if ($envelope->all(ReceivedStamp::class)) {
+            $this->newrelicManager->startTransaction();
+            $this->newrelicManager->nameTransaction(
+                $this->newrelicTransactionNameManager->getTransactionName($envelope)
+            );
+            try {
+                return $stack->next()->handle($envelope, $stack);
+            } catch (HandlerFailedException $e) {
+                $this->newrelicManager->noticeError($e);
+                throw $e;
+            } finally {
+                $this->newrelicManager->endTransaction();
+            }
         }
+
+        if ($envelope->all(NewrelicTransactionStamp::class)) {
+            return $stack->next()->handle($envelope, $stack);
+        }
+
+        return $stack->next()->handle(
+            $envelope->with(
+                new NewrelicTransactionStamp(
+                    $this->newrelicTransactionNameManager->getTransactionName($envelope)
+                )
+            ),
+            $stack
+        );
     }
 }

--- a/Newrelic/NewrelicTransactionNameManager.php
+++ b/Newrelic/NewrelicTransactionNameManager.php
@@ -6,13 +6,36 @@ use Symfony\Component\Messenger\Envelope;
 
 class NewrelicTransactionNameManager
 {
+    /**
+     * @var array<class-string, string>
+     */
+    private array $transactionNameRegistry = [];
+
+    /**
+     * @param class-string $class
+     * @param string       $transactionName
+     *
+     * @return $this
+     */
+    public function addTransactionMapping(string $class, string $transactionName): self
+    {
+        $this->transactionNameRegistry[$class] = $transactionName;
+
+        return $this;
+    }
+
     public function getTransactionName(Envelope $envelope): string
     {
+        $stamp = $envelope->last(NewrelicTransactionStamp::class);
+        if (null !== $stamp) {
+            return $stamp->getTransactionName();
+        }
+
         $message = $envelope->getMessage();
         if ($message instanceof NameableNewrelicTransactionInterface) {
             return $message->getNewrelicTransactionName();
         }
 
-        return get_class($message);
+        return $this->transactionNameRegistry[$class = get_class($message)] ?? $class;
     }
 }

--- a/Newrelic/NewrelicTransactionStamp.php
+++ b/Newrelic/NewrelicTransactionStamp.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Arxus\NewrelicMessengerBundle\Newrelic;
+
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+class NewrelicTransactionStamp implements StampInterface
+{
+    public function __construct(
+        private string $transactionName
+    ) {
+    }
+
+    public function getTransactionName(): string
+    {
+        return $this->transactionName;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -22,6 +22,48 @@ framework:
                 middleware:
                     - Arxus\NewrelicMessengerBundle\Middleware\NewRelicMiddleware
 ```
+## Usage
+
+Originally, all message classes had to implement `NameableNewrelicTransactionInterface`:
+```php
+class SampleMessage implements \Arxus\NewrelicMessengerBundle\Newrelic\NameableNewrelicTransactionInterface
+{
+    public function getNewrelicTransactionName() {
+        return 'MyCustom/Transaction-Name';
+    }
+}
+```
+
+Since version 0.6, it's also possible to register mappings by calling
+`NewrelicTransactionNameManager::addTransactionMapping` passing the target message class FQN
+and transaction name as arguments:
+```php
+class SampleMessage
+{
+    // ...
+}
+
+class SampleService
+{
+    public function __construct(
+        private \Arxus\NewrelicMessengerBundle\Newrelic\NewrelicTransactionNameManager $newrelicTrxNameManager
+    ) {
+        $this->newrelicTrxNameManager->addTransactionMapping(SampleMessage::class, 'MyCustom/Transaction-Name');
+    }
+}
+```
+
+This can also be used via Symfony's Dependency Injection:
+```yaml
+services:
+    # ...
+    Arxus\NewrelicMessengerBundle\Newrelic\NewrelicTransactionNameManager:
+      class: Arxus\NewrelicMessengerBundle\Newrelic\NewrelicTransactionNameManager
+      calls:
+        - addTransactionMapping: ['\App\Messenger\Message\SampleMessage', 'MyCustom/Transaction-Name']
+    # ...
+```
+
 ## Expected results
 When newrelic is correctly installed and configured on your host,
 it should report each consumed message as a separate transaction,

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ class SampleService
 }
 ```
 
-This can also be used via Symfony's Dependency Injection:
+This can also be used via Symfony's Dependency Injection, with no need to create any new services or change existing service's code:
 ```yaml
 services:
     # ...

--- a/tests/Newrelic/NewrelicTransactionNameManagerTest.php
+++ b/tests/Newrelic/NewrelicTransactionNameManagerTest.php
@@ -1,9 +1,10 @@
 <?php declare(strict_types=1);
 
-namespace Arxus\NewrelicMessengerBundle\Tests\Middleware;
+namespace Arxus\NewrelicMessengerBundle\Tests\Newrelic;
 
 use Arxus\NewrelicMessengerBundle\Newrelic\NameableNewrelicTransactionInterface;
 use Arxus\NewrelicMessengerBundle\Newrelic\NewrelicTransactionNameManager;
+use Arxus\NewrelicMessengerBundle\Newrelic\NewrelicTransactionStamp;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 
@@ -36,6 +37,28 @@ class NewrelicTransactionNameManagerTest extends TestCase
             ->method('getNewrelicTransactionName')
             ->willReturn($randomTransactionName);
         $envelope = new Envelope($messageMock);
+        $transactionName = $this->newrelicTransactionNameManager->getTransactionName($envelope);
+
+        $this->assertEquals($randomTransactionName, $transactionName);
+    }
+
+    public function test_transaction_name_with_stamp(): void
+    {
+        $randomTransactionName = uniqid('transactionName_');
+        $envelope = new Envelope(
+            new \stdClass(),
+            [new NewrelicTransactionStamp($randomTransactionName)]
+        );
+        $transactionName = $this->newrelicTransactionNameManager->getTransactionName($envelope);
+
+        $this->assertEquals($randomTransactionName, $transactionName);
+    }
+
+    public function test_transaction_name_with_mapping(): void
+    {
+        $randomTransactionName = uniqid('transactionName_');
+        $this->newrelicTransactionNameManager->addTransactionMapping(\stdClass::class, $randomTransactionName);
+        $envelope = new Envelope(new \stdClass());
         $transactionName = $this->newrelicTransactionNameManager->getTransactionName($envelope);
 
         $this->assertEquals($randomTransactionName, $transactionName);


### PR DESCRIPTION
This could be a better option for implementation in already-deployed projects, since it does not require changes to the message body, but instead uses a Stamp - which usually gets sent in the headers or metadata in most transports (and Symfony Messenger deals with it transparently, either way).

I've tried keeping full BC with the previous interface-way, so if there's no NewrelicTransactionStamp, it'll fallback to checking if it's an instance of the interface. If it still isn't, then it'll check if there's a registered mapping (class-name => transaction-name) and use it, otherwise, just return the class-name as it would before.

I'm working on a follow-up to add mappings via YAML configuration and/or attributes, but it's not ready yet. At the current stage, the suggested usage would be to add calls to the new `NewrelicTransactionNameManager::addTransactionMapping` method directly via DI, with each message-class-FQN and it's expected transaction name as arguments:

<details>
<summary>via YAML (config/services.yaml)</summary>

```yaml
services:
    # ...
    Arxus\NewrelicMessengerBundle\Newrelic\NewrelicTransactionNameManager:
      class: Arxus\NewrelicMessengerBundle\Newrelic\NewrelicTransactionNameManager
      calls:
        - addTransactionMapping: ['\App\Messenger\Message\SampleMessage', 'MyCustom/Transaction-Name']
    # ...
```

</details>
<details>
<summary>via PHP (config/services.php)</summary>

```php
<?php

namespace Symfony\Component\DependencyInjection\Loader\Configurator;

return function(ContainerConfigurator $container): void {
    // ...
    $container->services()
        ->set(Arxus\NewrelicMessengerBundle\Newrelic\NewrelicTransactionNameManager::class)
            ->call(
                'addTransactionMapping',
                [
                    App\Messenger\Message\SampleMessage::class,
                    'MyCustom/Transaction-Name'
                ]
            );
    // ...
};
```

</details>
<details>
<summary>via XML (config/services.xml)</summary>

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<container xmlns="http://symfony.com/schema/dic/services"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://symfony.com/schema/dic/services
        https://symfony.com/schema/dic/services/services-1.0.xsd">

    <services>
		<!-- ... -->
        <service id="Arxus\NewrelicMessengerBundle\Newrelic\NewrelicTransactionNameManager" class="Arxus\NewrelicMessengerBundle\Newrelic\NewrelicTransactionNameManager">
            <call method="addTransactionMapping">
                <argument>\App\Messenger\Message\SampleMessage</argument>
                <argument>MyCustom/Transaction-Name</argument>
            </call>
        </service>
		<!-- ... -->
    </services>
</container>
```

</details>

Otherwise, the `NewrelicTransactionNameManager` can be injected into each message's existing Handler's constructor (or any other message-related service, for that matter, as long as it's not lazy-initialized), and the call can occur there:
<details>
<summary>Example</summary>

```php
<?php

namespace App\Messenger\Handler;

use App\Messenger\Message\MyMessage;
use Arxus\NewrelicMessengerBundle\Newrelic\NewrelicTransactionNameManager;

class MyMessageHandler
{
    public function __construct(
        // ...
        NewrelicTransactionNameManager $newrelicTxnNameMgr,
        // ...
    ) {
        // ...
        $newrelicTxnNameMgr->addTransactionMapping(MyMessage::class, 'MyCustom/Transaction-Name');
        // ...
    }
    // ...
}
```

</details>

And as a "low-level" approach, one can always just add a `NewrelicTransactionStamp` to the envelope before serialization.